### PR TITLE
調整部分圖片替代文字

### DIFF
--- a/_includes/events.html
+++ b/_includes/events.html
@@ -33,11 +33,11 @@
 
     <div class="image">
       {% if item.cover %}
-      <img src="{{ item.cover }}" alt="Cover image for '{{ item.name }}'" />
+      <img src="{{ item.cover }}" alt="" />
       {% elsif item.avatar %}
-      <img src="{{ item.avatar }}" alt="Cover image for '{{ item.name }}'" />
+      <img src="{{ item.avatar }}" alt="" />
       {% elsif item.banner %}
-      <img src="{{ item.banner }}" alt="Cover image for '{{ item.name }}'" />
+      <img src="{{ item.banner }}" alt="" />
       {% endif %}
     </div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
   <div class="ui stripe container">
 
     <h2 class="ui inverted small center aligned header">
-      <img src="{{ site.data.people.orgs.ocf.icon }}" alt="Logo of '{{ site.data.people.orgs.ocf.name }}'" />
+      <img src="{{ site.data.people.orgs.ocf.icon }}" alt="" />
       <div class="content">
         {% if page.lang == "en" %}
         {{ site.data.people.orgs.ocf.name_en }}

--- a/_includes/menu_desktop.html
+++ b/_includes/menu_desktop.html
@@ -1,5 +1,5 @@
 <a class="logo item" href="/">
-  <img class="ui logo image" src="{{ site.data.people.orgs.ocf.icon }}" alt="Logo of '{{ site.data.people.orgs.ocf.name }}'">
+  <img class="ui logo image" src="{{ site.data.people.orgs.ocf.icon }}" alt="">
   {% if page.lang == "en" %}
   {{ site.data.people.orgs.ocf.name_en }}
   {% else %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -29,7 +29,7 @@ layout: global
   {% else %}
   src="{{ project.cover }}"
   {% endif %}
-  style="opacity: {{ page.cover_image_opacity }}" alt="Cover image for '{{ project.name }}'" / />
+  style="opacity: {{ page.cover_image_opacity }}" alt="" / />
   <div class="cover" style="opacity: {{ page.cover_veil_opacity }}"></div>
   <hr class="ui hidden section divider" />
 
@@ -92,7 +92,7 @@ layout: global
         {% assign org = site.data.people.orgs[org_id] %}
         <a class="item" target="_blank" href="{{ org.link[1].url }}">
           {% if org.logo %}
-          <img class="logo" src="{{ org.logo }}" alt="Logo of {{ org.name }}" />
+          <img class="logo" src="{{ org.logo }}" alt="{{ org.name }}" />
           {% else %}
           {{ org.name }}
           {% endif %}

--- a/_layouts/report.html
+++ b/_layouts/report.html
@@ -21,12 +21,12 @@ layout: global
 <header id="hero" class="ui inverted {{ site.data.reports[ report_id ].color }} center aligned basic very padded segment marginless">
 
   <!-- 若有需要，可在檔頭做設定，調整背景圖的透明度跟混色 -->
-  <img class="cover image" src="{{ site.data.reports[ report_id ].cover }}" style="opacity: {{ site.data.reports[ report_id ].cover_image_opacity }}" alt="Cover image for '{{ site.data.reports[ report_id ].title }}'" />
+  <img class="cover image" src="{{ site.data.reports[ report_id ].cover }}" style="opacity: {{ site.data.reports[ report_id ].cover_image_opacity }}" alt="" />
   <div class="cover" style="opacity: {{ site.data.reports[ report_id ].cover_veil_opacity }}"></div>
   <hr class="ui hidden divider" />
 
   <div class="ui stripe relative container">
-    <img class="ui centered tiny image" src="{{ site.data.people.orgs.ocf.icon }}" alt="Logo image of '{{ site.data.people.orgs.ocf.name }}'"/>
+    <img class="ui centered tiny image" src="{{ site.data.people.orgs.ocf.icon }}" alt=""/>
     <h1 class="ui inverted header">
       {{ site.data.reports[ report_id ].title }}
     </h1>
@@ -82,7 +82,7 @@ layout: global
   <!-- 根據資料產生 image 欄內容，同時決定位置是否要左右對調 -->
   {% if column.type == "image" %}
   <div class="column{% if column.swap %} flex-swap{% endif %}" data-type="{{ column.type }}">
-    <img class="ui image" src="{{ column.url }}" alt="Image for the following section" />
+    <img class="ui image" src="{{ column.url }}" alt="" />
   </div>
 
   <!-- 根據資料產生 image slider 欄內容，同時決定位置是否要左右對調 -->
@@ -234,11 +234,11 @@ layout: global
       {% if logo.org_id %}
         {% assign org = site.data.people.orgs[ logo.org_id ] %}
         <a class="item" {% if org.link[0].url %} target="_blank" href="{{ org.link[0].url }}"{% else %} style="cursor: auto;" {% endif %}>
-          <img class="logo" src="{{ org.logo }}" alt="Log of '{{ org.name }}'" style="height: {{ column.logo_height }};"/>
+          <img class="logo" src="{{ org.logo }}" alt="{{ org.name }}" style="height: {{ column.logo_height }};"/>
         </a>
       {% else %}
         <a class="item" {% if logo.url %} target="_blank" href="{{ logo.url }}"{% else %} style="cursor: auto;" {% endif %}>
-          <img class="logo" src="{{ logo.src }}" alt="Logo of '{{ logo.title }}'" style="height: {{ column.logo_height }};"/>
+          <img class="logo" src="{{ logo.src }}" alt="{{ logo.title }}" style="height: {{ column.logo_height }};"/>
         </a>
       {% endif %}
 

--- a/en/index.html
+++ b/en/index.html
@@ -45,7 +45,7 @@ lang: en
     {% assign data = year[1] %}
     <div class="item">
       <div class="image">
-        <img src="{{ data.cover }}" alt="Cover image for '{{ data.title }}'">
+        <img src="{{ data.cover }}" alt="">
       </div>
       <div class="content">
         <a href="/en/p/{{ year[0] | remove: '_en' }}" class="header">{{ data.title }}</a>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@ ongoing:
   {% assign org = site.data.people.orgs[org_id] %}
 
       <a class="item" target="_blank" href="{{ org.link[0].url }}">
-        <img class="logo" src="{{ org.logo }}" alt="Logo of '{{ org.name }}'" />
+        <img class="logo" src="{{ org.logo }}" alt="{{ org.name }}" />
       </a>
 
   {% endfor %}
@@ -259,7 +259,7 @@ ongoing:
   {% for org_id in site.data.people.relations.sponsors %}
   {% assign org = site.data.people.orgs[org_id] %}
       <a class="item" target="_blank" href="{{ org.link[0].url }}">
-        <img class="logo" src="{{ org.logo }}" alt="Logo of '{{ org.name }}'" />
+        <img class="logo" src="{{ org.logo }}" alt="{{ org.name }}" />
       </a>
   {% endfor %}
 
@@ -293,7 +293,7 @@ ongoing:
     {% assign project = site.data.projects[current][project_id] %}
       <div class="card">
         <div class="image">
-          <img src="{{ project.cover }}" alt="Cover image for '{{ project.name }}'" />
+          <img src="{{ project.cover }}" alt="" />
         </div>
         <div class="content">
           <h3 class="header">{{ project.name }}</h3>

--- a/mediakit/branding.html
+++ b/mediakit/branding.html
@@ -12,13 +12,13 @@ Muka Wang</a></p>
 <h3 class="ui header">正方 logo</h3>
 <div class="ui secondary segment basic marginless">
 <div class="ui fluid image">
-  <img src="{{ site.data.people.orgs.ocf.avatar }}" alt="Logo of '{{ site.data.people.orgs.ocf.name }}'" />
+  <img src="{{ site.data.people.orgs.ocf.avatar }}" alt="Square Logo of '{{ site.data.people.orgs.ocf.name }}'" />
 </div>
 </div>
 
 <h3 class="ui header">背景樣式</h3>
 <div class="ui secondary segment basic marginless">
 <div class="ui fluid image">
-  <img src="{{ site.data.people.orgs.ocf.cover }}" alt="Logo of '{{ site.data.people.orgs.ocf.name }}'" />
+  <img src="{{ site.data.people.orgs.ocf.cover }}" alt="Background Logo of '{{ site.data.people.orgs.ocf.name }}'" />
 </div>
 </div>

--- a/news/index.html
+++ b/news/index.html
@@ -36,7 +36,7 @@ og_description: 開源開放大小事，搶鮮送到你家！OCF 電子報，每
 
           <div class="item">
             <div class="image">
-              <img src="{{ item.cover }}" alt="Cover image for '{{ item.title }}'" />
+              <img src="{{ item.cover }}" alt="" />
             </div>
             <div class="content">
               <h4 class="ui header">

--- a/p/index.html
+++ b/p/index.html
@@ -94,7 +94,7 @@ js: /assets/projects.js
       {% endfor %}
       ">
         <div class="image">
-          <img src="https://images.weserv.nl/?url=ocf.tw/{{ project.cover }}&w=500" alt="Cover image for '{{project.name}}'">
+          <img src="https://images.weserv.nl/?url=ocf.tw/{{ project.cover }}&w=500" alt="">
         </div>
         <div class="content">
           <h3 class="header">
@@ -197,7 +197,7 @@ js: /assets/projects.js
     {% assign data = year[1] %}
     <div class="item">
       <div class="image">
-        <img src="https://images.weserv.nl/?url=ocf.tw/{{ data.cover }}&w=300" alt="Cover image for '{{ data.title }}'">
+        <img src="https://images.weserv.nl/?url=ocf.tw/{{ data.cover }}&w=300" alt="">
       </div>
       <div class="content">
         <a href="/p/{{ year[0] }}" class="header">{{ data.title }}</a>

--- a/people/index.html
+++ b/people/index.html
@@ -64,7 +64,7 @@ css: /assets/people.css
 
         {% if person.avatar %}
         <div class="avatar image">
-          <img src="{{ person.avatar }}" alt="Avatar image for '{{ person.name }}'" />
+          <img src="{{ person.avatar }}" alt="" />
         </div>
         {% endif %}
 
@@ -121,7 +121,7 @@ css: /assets/people.css
       {% for org_id in site.data.people.relations[item.id] %}
       {% assign org = site.data.people.orgs[org_id] %}
       <a class="item" target="_blank" href="{{ org.link[0].url }}">
-        <img class="logo" src="{{ org.logo }}" alt="Logo of '{{ org.name }}'" />
+        <img class="logo" src="{{ org.logo }}" alt="{{ org.name }}" />
       </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
基本上是參考 W3C 文件 [3.14][ref]
有些不需要的文字先移除了

大概原則是：

* 只有文字時不影響閱讀（ex:「合作伙伴：Logo of 新竹貨運」就怪怪的，只需要「合作伙伴：新竹貨運」）
* 重複資訊時就不需要替代文字（ex: 「新竹貨運（替代文字） 新竹貨運（標題）」這樣就有重複資訊）

[ref]:https://dev.w3.org/html5/alt-techniques/#logos